### PR TITLE
cuda-nvcc-impl v12.9.86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+# - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,26 +1,27 @@
 c_compiler_version:        # [linux]
-  - 12                     # [linux]
+  - 14                     # [linux]
 cxx_compiler_version:      # [linux]
-  - 12                     # [linux]
+  - 14                     # [linux]
 # For some reason, the minimum glibc version for tegra is much higher than sbsa
 c_stdlib_version:  # [linux and aarch64]
-  - "2.17"  # [linux and aarch64]
-  - "2.34"  # [linux and aarch64]
+  - "2.28"  # [linux and aarch64]
+#  - "2.34"  # [linux and aarch64]
 
 arm_variant_type:  # [linux and aarch64]
   - sbsa           # [linux and aarch64]
-  - tegra          # [linux and aarch64]
+#  - tegra          # [linux and aarch64]
 
+# CUDA Toolkit 12.9 supports VS 2022
 VCVER:                     # [win]
-  - 14.2                   # [win]
+  - 14.42                  # [win]
 VSYEAR:                    # [win]
-  - 2019                   # [win]
+  - 2022                   # [win]
 CL_VERSION:                # [win]
-  - 19.29.30139            # [win]
+  - 19.44.35207            # [win]
 c_compiler:                # [win]
-  - vs2019                 # [win]
+  - vs2022                 # [win]
 cxx_compiler:              # [win]
-  - vs2019                 # [win]
+  - vs2022                 # [win]
 
 zip_keys:
   -                        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,12 +7,10 @@
 {% set gcc_min_constraint = ">=6" %}
 {% set gcc_constraint = ">=6,<15.0a0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type == "sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type == "tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type == "sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type == "tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -37,9 +35,9 @@ source:
     - nvcc.profile.patch.win  # [win]
 
 build:
-  number: 2
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -48,6 +46,8 @@ requirements:
 
 outputs:
   - name: cuda-nvcc-tools
+    build:
+      binary_relocation: false
     files:   # [linux]
       - bin/__nvcc_device_query  # [linux]
       - bin/bin2c                # [linux]
@@ -89,10 +89,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Architecture independent part of CUDA NVCC compiler.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvcc-dev_{{ target_platform }}
     build:
@@ -141,10 +143,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Target architecture dependent parts of CUDA NVCC compiler.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: libnvptxcompiler-dev
     files:  # [linux]
@@ -168,10 +172,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Target architecture dependent parts of CUDA nvptxcompiler.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: libnvptxcompiler-dev_{{ target_platform }}
     build:
@@ -198,10 +204,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Target architecture dependent parts of CUDA nvptxcompiler.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvcc-impl
     build:
@@ -256,10 +264,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_other: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-crt-tools
     files:
@@ -282,10 +292,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA internal tools.
       description: |
         CUDA internal tools.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-crt-dev_{{ target_platform }}
     build:
@@ -311,10 +323,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA internal headers.
       description: |
         CUDA internal headers.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvvm-tools
     files:
@@ -347,10 +361,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvvm-dev_{{ target_platform }}
     build:
@@ -371,15 +387,20 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvvm-impl
     build:
       # libnvvm.so gets corrupted by patchelf. No need to relocate as it is already relocatable.
       binary_relocation: false
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libnvvm*.so*'         # [linux and aarch64]
     files:
       - nvvm/include          # [linux]
       - nvvm/lib64            # [linux]
@@ -410,20 +431,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Compiler for CUDA applications.
   description: |
     Compiler for CUDA applications.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   feedstock-name: cuda-nvcc-impl

--- a/recipe/patchelf_exclude.txt
+++ b/recipe/patchelf_exclude.txt
@@ -1,4 +1,4 @@
-crt/link.stub
-crt/prelink.stub
+link.stub
+prelink.stub
 nvcc.profile
 patchelf

--- a/recipe/run_nvcc_tests.sh
+++ b/recipe/run_nvcc_tests.sh
@@ -39,7 +39,7 @@ fi
 
 mkdir -p cmake-tests
 git clone -b v${cmake_version} --depth 1 https://gitlab.kitware.com/cmake/cmake.git cmake-tests
-cmake -S cmake-tests -B cmake-tests/build -DCMake_TEST_HOST_CMAKE=ON -DCMake_TEST_CUDA=nvcc -G "Ninja"
+cmake -S cmake-tests -B cmake-tests/build -DCMake_TEST_HOST_CMAKE=ON -DCMake_TEST_CUDA=nvcc -G "Ninja" -DCMake_TEST_CUDA_ARCH=75
 cd cmake-tests/build
 
 # Test exclusion list:
@@ -62,6 +62,18 @@ cd cmake-tests/build
 #   CudaOnly.OptixIR
 #   RunCMake.CUDA_architectures
 #   *Toolkit*
+#
 # Failing due to undefined symbol: __libc_dl_error_tsd, version GLIBC_PRIVATE
 #   Cuda.Complex
-CUDAHOSTCXX=$CXX ctest -L CUDA --output-on-failure -j $(nproc) -E "(Architecture|CompileFlags|DeviceLTO|ProperDeviceLibraries|SharedRuntime|ObjectLibrary|WithC|StubRPATH|ArchSpecial|GPUDebugFlag|SeparateCompilationPTX|WithDefs|CUBIN|Fatbin|OptixIR|CUDA_architectures|Toolkit|Cuda.Complex)"
+#
+# Failing due to error: "__is_nothrow_new_constructible" is not a function or static data member
+#   Cuda.CXXStandardSetTwice
+#   Cuda.MixedStandardLevels1
+#   Cuda.ProperLinkFlags
+#   CudaOnly.EnableStandard
+#   CudaOnly.CircularLinkLine
+#   CudaOnly.SeparateCompilation
+#   CudaOnly.DontResolveDeviceSymbols
+#   CudaOnly.RuntimeControls
+#
+CUDAHOSTCXX=$CXX ctest -L CUDA --output-on-failure -j $(nproc) -E "(Architecture|CompileFlags|DeviceLTO|ProperDeviceLibraries|SharedRuntime|ObjectLibrary|WithC|StubRPATH|ArchSpecial|GPUDebugFlag|SeparateCompilationPTX|WithDefs|CUBIN|Fatbin|OptixIR|CUDA_architectures|Toolkit|Cuda.Complex|Cuda.CXXStandardSetTwice|Cuda.MixedStandardLevels1|Cuda.ProperLinkFlags|CudaOnly.EnableStandard|CudaOnly.CircularLinkLine|CudaOnly.SeparateCompilation|CudaOnly.DontResolveDeviceSymbols|CudaOnly.RuntimeControls)"


### PR DESCRIPTION
cuda-nvcc-impl 12.9.86

**Destination channel:** defaults

### Links

- [PKG-12794](https://anaconda.atlassian.net/browse/PKG-12794) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.

### Notes:

- Set minimum GCC version to GCC 14 (for Linux)
- Set minimum Visual Studio version to VS2022 (for Windows)
- Updated list of excluded tests; `CXX_STANDARD` won't apply for some reason, so cannot remove `-std=c++11` argument passed to the `nvcc` during tests
- Updated `patchelf_exclude.txt`; needed to remote the `crt/` prefix to make `*.stub` correctly excluded.
- Copied `-DCMake_TEST_CUDA_ARCH=75` argument from CUDA 13.1's CMake configure argument list. This is about standardization of tests between CUDA 12.x and 13.x. Also, testing a single compute capability should be enough and it shouldn't make any difference in general.
- Similar changes were made on CUDA 12.8 release

[PKG-12794]: https://anaconda.atlassian.net/browse/PKG-12794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ